### PR TITLE
新規登録時挙動修正

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -1,6 +1,6 @@
 class SignupController < ApplicationController
   include RedirectToTop
-  before_action :redirect_to_top
+  before_action :redirect_to_top, except: :done
   before_action :save_to_session_before_phone, only: :phone
   before_action :save_to_session_before_address, only: :address
   before_action :save_to_session_before_credit, only: :credit
@@ -20,6 +20,7 @@ class SignupController < ApplicationController
     session[:birthdate_year] = "--" #生年月日の年、初期値設定
     session[:birthdate_month] = "--" #生年月日の月、初期値設定
     session[:birthdate_day] = "--" #生年月日の日、初期値設定
+    session[:email_signup] = params[:email_signup]
   end
 
 
@@ -66,10 +67,14 @@ class SignupController < ApplicationController
     # sns_credentialsテーブルのインスタンス作成（メールアドレスでの登録を除く）
     @user.sns_credentials.build(provider: session[:provider], uid: session[:uid]) if session[:provider] && session[:uid]
     if @user.save
-      sign_in @user
+      session[:id] = @user.id
       redirect_to done_signup_index_path
     else
       render '/signup/registration'
+    end
+
+    def done
+      sign_in User.find(session[:id]) unless user_signed_in?
     end
   end
     

--- a/app/views/signup/registration.html.haml
+++ b/app/views/signup/registration.html.haml
@@ -40,7 +40,7 @@
             - else # メールアドレスでの登録時
               = f.email_field :email, class: 'first-main__form--input', placeholder: 'PC・携帯どちらでも可'
               = render partial: 'error-message', locals: {user: @user, column: "email"}
-          - if session[:password] && params[:email_signup] != "yes" # メールアドレスでの登録でないことを確認
+          - if session[:email_signup] != "yes" # メールアドレスでの登録でないことを確認
             .first-main__form{style: 'display: none;'}
               = f.label 'パスワード', class: 'first-main__form--label'
               %span.first-main__form--require 必須

--- a/spec/controllers/signup_controller_spec.rb
+++ b/spec/controllers/signup_controller_spec.rb
@@ -246,9 +246,9 @@ describe SignupController do
     end
 
     describe 'GET #done' do
-      it "redirect_to the top page" do
+      it "renders the :done template" do
         get :done
-        expect(response).to redirect_to products_path
+        expect(response).to render_template :done
       end
     end
   end


### PR DESCRIPTION
# WHAT
新規登録時に、最後にメルカリを始めるページにバリデーション下で飛ぶように調整
テストの記述変更
registration.html.hamlの条件分岐の条件を変更

# WHY
メルカリの挙動と同じにするため