### PR TITLE
商品出品・編集ページの微修正

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -89,9 +89,9 @@ class ProductsController < ApplicationController
     end
     # 販売価格の表示
     # 販売手数料の初期値
-    @sales_fee = "#{(@product.price.to_i*0.1).round}"
+    @sales_fee = (@product.price.to_i*0.1).round
     # 販売利益の初期値
-    @sales_profit = "#{(@product.price.to_i*0.9).round}"
+    @sales_profit = (@product.price.to_i*0.9).round
   end
   
   def update

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -144,7 +144,7 @@ class ProductsController < ApplicationController
 
   def check_validation_create
     @product = Product.new(product_params)
-    render '/products/new' unless @product.valid? 
+    render '/products/new' unless @product.valid?(:create)
   end
 
   private

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,6 +10,7 @@ class Users::SessionsController < Devise::SessionsController
     super
     session[:flag] = "signin" #signinページであることを示す目印
     session[:error] = nil #エラーメッセージの初期化
+    alert = nil
   end
 
   # POST /resource/sign_in

--- a/app/helpers/product_helper.rb
+++ b/app/helpers/product_helper.rb
@@ -1,0 +1,5 @@
+module ProductHelper
+  def converting_to_jpy(price)
+    "¥#{price.to_s(:delimited, delimiter: ',')}"
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -7,7 +7,7 @@ class Product < ApplicationRecord
   belongs_to :products_size, optional: true
 
   # バリデーション
-  validates :photos, length: { in: 1..10, message: "は1枚以上10枚以下で選択してください"}
+  validates :photos, length: { in: 1..10, message: "は1枚以上10枚以下で選択してください"}, on: :create
   validates :product_name, length: { in: 1..40 }
   validates :product_introduction, length: { in: 1..1000 }
   validates :category_id, numericality: {message: 'を選択してください'}

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -140,11 +140,11 @@
 
         .form-right-justified-sub
           = f.label "販売手数料(10%)", class: 'form-right-justified-sub__label'
-          #sf-tag.form-right-justified-sub__fee="¥#{@sales_fee}"
+          #sf-tag.form-right-justified-sub__fee=converting_to_jpy(@sales_fee)
 
         .form-right-justified-main
           = f.label "販売利益", class: 'form-right-justified-main__label'
-          #sp-tag.form-right-justified-main__revenue="¥#{@sales_profit}"
+          #sp-tag.form-right-justified-main__revenue=converting_to_jpy(@sales_profit)
 
     -# 送信＆注意書き
     .listing-content.clearfix


### PR DESCRIPTION
# WHAT
画像へのRailsによるバリデーションを商品出品のみに適用させる
編集ページの初期値、販売手数料と販売利益に桁区切りを追加する

# WHY
バリデーションの不具合を修正するため
UXを高めるため