### PR TITLE
[WIP]商品購入画像引っ張り

### DIFF
--- a/app/views/purchase/index.html.haml
+++ b/app/views/purchase/index.html.haml
@@ -7,7 +7,7 @@
     %div.content__main
       .content__main--item
       %span.content__main--item-image
-        = image_tag '/images/m37585938822_1.jpg', size: "64x64"
+        = image_tag @product.photos[0].variant(resize:'64x64').processed
       %p.content__main--item-name adidas アディダス Tシャツ
 
 


### PR DESCRIPTION
自分のローカルではカード登録できなかったので、確認はできてないが理論上これで引っ張れる。基本サイズを'64x64'・画像が縦長の時はそれに準拠した表示にしたいがActiveStorageでそこまで細かく画像をいじれる方法が不明。