### PR TITLE
他の商品を表示　実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -17,6 +17,8 @@ class ProductsController < ApplicationController
     @product = Product.with_attached_photos.find(params[:id])
     # with_attached_photos は Active Storage の n+1 問題を解決してくれるメソッド
     # with_attached_photos は .all と動作が同じなので .find で細かな指定をする
+    @product_other = Product.where(exhibitor_id: @product.exhibitor_id).where.not(id:@product.id)
+    @other_category = Product.where(category_id: @product.category_id).where.not(id:@product.id)
   end
   
   def new

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -104,88 +104,37 @@
     %section.item-others--seller
       %h2.item-others--seller_name 出品者のその他の商品
       .item-others--seller_product.clearfix
-
-        .item-others--seller_product_box
-          .items-box_photo
-            = link_to image_tag "https://static.mercdn.net/thumb/photos/m80174371277_1.jpg", href:"", size: "210x200"
-          .items-box_body
-            %h3.items-box-name
-              ビンテージ 1963年製 バービー人形マテル スイス製手巻き腕時計
-            .items-box-num
-              .items-box-price
-                ￥6,000
-              .items-box-icon
-                %i.far.fa-heart
-                8
-
-        .item-others--seller_product_box
-          .items-box_photo
-            = link_to image_tag "https://static.mercdn.net/thumb/photos/m80174371277_1.jpg", href:"", size: "210x200"
-          .items-box_body
-            %h3.items-box-name
-              ビンテージ 1963年製 バービー人形マテル スイス製手巻き腕時計
-            .items-box-num
-              .items-box-price
-                ￥6,000
-              .items-box-icon
-                %i.far.fa-heart
-                8
-
-        .item-others--seller_product_box
-          .items-box_photo
-            = link_to image_tag "https://static.mercdn.net/thumb/photos/m80174371277_1.jpg", href:"", size: "210x200"
-          .items-box_body
-            %h3.items-box-name
-              ビンテージ 1963年製 バービー人形マテル スイス製手巻き腕時計
-            .items-box-num
-              .items-box-price
-                ￥6,000
-              .items-box-icon
-                %i.far.fa-heart
-                8
+        - @product_other.each_with_index do |product_other, i|
+          .item-others--seller_product_box
+            .items-box_photo
+              = image_tag product_other.photos[0].variant(resize:'210x200',auto_orient: true).processed
+            .items-box_body
+              %h3.items-box-name
+                = product_other.product_name
+              .items-box-num
+                .items-box-price
+                  ¥
+                  = product_other.price
+                .items-box-icon
+                  %i.far.fa-heart
+                  8
  
 
     %section.item-others--product
       %h2.item-others--product__category-name 同カテゴリーその他の商品
       .item-others--product__content
-
+      - @other_category.each_with_index do |other_category, i|
         .item-others--product__content-product-box
           .items-box_photo
-            = link_to image_tag "https://static.mercdn.net/thumb/photos/m80174371277_1.jpg", href:"", size: "210x200"
+            = link_to image_tag other_category.photos[0].variant(resize:'210x200',auto_orient: true).processed
           .items-box_body
             %h3.items-box-name
-              ビンテージ 1963年製 バービー人形マテル スイス製手巻き腕時計
+              = other_category.product_name
             .items-box-num
               .items-box-price
-                ￥6,000
+                ￥
+                = other_category.price
               .items-box-icon
                 %i.far.fa-heart
                 8
-
-        .item-others--product__content-product-box
-          .items-box_photo
-            = link_to image_tag "https://static.mercdn.net/thumb/photos/m80174371277_1.jpg", href:"", size: "210x200"
-          .items-box_body
-            %h3.items-box-name
-              ビンテージ 1963年製 バービー人形マテル スイス製手巻き腕時計
-            .items-box-num
-              .items-box-price
-                ￥6,000
-              .items-box-icon
-                %i.far.fa-heart
-                8
-
-        .item-others--product__content-product-box
-          .items-box_photo
-            = link_to image_tag "https://static.mercdn.net/thumb/photos/m80174371277_1.jpg", href:"", size: "210x200"
-          .items-box_body
-            %h3.items-box-name
-              ビンテージ 1963年製 バービー人形マテル スイス製手巻き腕時計
-            .items-box-num
-              .items-box-price
-                ￥6,000
-              .items-box-icon
-                %i.far.fa-heart
-                8
-
 = render 'layouts/footer'

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -69,7 +69,7 @@
     .item-container1__item-price
       %span.item-container1__item-price-bold
         ¥
-        = @product.price
+        = number_with_delimiter(@product.price)
       %span.item-container1__item-price-tax (税込)
       %span.item-container1__item-price-shipping-fee
         = @product.delivery_charge
@@ -114,7 +114,7 @@
               .items-box-num
                 .items-box-price
                   ¥
-                  = product_other.price
+                  = number_with_delimiter(product_other.price)
                 .items-box-icon
                   %i.far.fa-heart
                   8
@@ -133,7 +133,7 @@
             .items-box-num
               .items-box-price
                 ￥
-                = other_category.price
+                = number_with_delimiter(other_category.price)
               .items-box-icon
                 %i.far.fa-heart
                 8


### PR DESCRIPTION
# WHAT
商品詳細ページの下部に同じ出品者の他の商品と、同カテゴリーの他の商品を表示する。

#WHY
UX向上の為