### PR TITLE
マイページサイドバーのリンク修正

### DIFF
--- a/app/assets/stylesheets/modules/mypage/_mypage-sidemenu.scss
+++ b/app/assets/stylesheets/modules/mypage/_mypage-sidemenu.scss
@@ -17,6 +17,7 @@
       position: relative;
     }
     &__link {
+      padding: 0 16px;
       &:hover { background-color: rgb(245, 245, 245); }
       background-color: white;
       min-height: 48px;
@@ -29,7 +30,6 @@
         color: black;
         text-decoration: none;
         &__name {
-          padding: 0 16px;
           color: black;
         }
       }

--- a/app/views/mypage/_mypage-sidemenu.html.haml
+++ b/app/views/mypage/_mypage-sidemenu.html.haml
@@ -1,80 +1,102 @@
 .l-side
   %ul.l-side__list
-    %li.l-side__list__link
-      = link_to "マイページ", "", class:"l-side__list__link__area__name"
-      %i.fas.fa-angle-right
-    %li.l-side__list__link
-      = link_to "お知らせ", "", class:"l-side__list__link__area__name"
-      %i.fas.fa-angle-right
-    %li.l-side__list__link
-      = link_to "やることリスト", "", class:"l-side__list__link__area__name"
-      %i.fas.fa-angle-right
-    %li.l-side__list__link
-      = link_to "いいね！ 一覧", "", class:"l-side__list__link__area__name"
-      %i.fas.fa-angle-right
-    %li.l-side__list__link
-      = link_to "出品する", "", class:"l-side__list__link__area__name"
-      %i.fas.fa-angle-right
-    %li.l-side__list__link
-      = link_to "出品した商品-出品中", "", class:"l-side__list__link__area__name"
-      %i.fas.fa-angle-right
-    %li.l-side__list__link
-      = link_to "出品した商品-取引中", "", class:"l-side__list__link__area__name"
-      %i.fas.fa-angle-right
-    %li.l-side__list__link
-      = link_to "出品した商品-売却済み", "", class:"l-side__list__link__area__name"
-      %i.fas.fa-angle-right
-
-    %li.l-side__list__link
-      = link_to "購入した商品-取引中", "", class:"l-side__list__link__area__name"
-      %i.fas.fa-angle-right
-    %li.l-side__list__link
-      = link_to "購入した商品-過去の取引", "", class:"l-side__list__link__area__name"
-      %i.fas.fa-angle-right
-    %li.l-side__list__link
-      = link_to "ニュース一覧", "", class:"l-side__list__link__area__name"
-      %i.fas.fa-angle-right
-    %li.l-side__list__link
-      = link_to "評価一覧", "", class:"l-side__list__link__area__name"
-      %i.fas.fa-angle-right
-    %li.l-side__list__link
-      = link_to "ガイド", "", class:"l-side__list__link__area__name"
-      %i.fas.fa-angle-right
-    %li.l-side__list__link
-      = link_to "お問い合わせ", "", class:"l-side__list__link__area__name"
-      %i.fas.fa-angle-right      
+    = link_to "", class:"l-side__list__link__area__name" do
+      %li.l-side__list__link
+        マイページ
+        %i.fas.fa-angle-right
+    = link_to "", class:"l-side__list__link__area__name" do
+      %li.l-side__list__link
+        お知らせ
+        %i.fas.fa-angle-right
+    = link_to "", class:"l-side__list__link__area__name" do
+      %li.l-side__list__link
+        やることリスト
+        %i.fas.fa-angle-right
+    = link_to "", class:"l-side__list__link__area__name" do
+      %li.l-side__list__link
+        いいね！ 一覧
+        %i.fas.fa-angle-right
+    = link_to "", class:"l-side__list__link__area__name" do
+      %li.l-side__list__link
+        出品する
+        %i.fas.fa-angle-right
+    = link_to "", class:"l-side__list__link__area__name" do
+      %li.l-side__list__link
+        出品した商品-出品中
+        %i.fas.fa-angle-right
+    = link_to "", class:"l-side__list__link__area__name" do
+      %li.l-side__list__link
+        出品した商品-取引中
+        %i.fas.fa-angle-right
+    = link_to "", class:"l-side__list__link__area__name" do
+      %li.l-side__list__link
+        出品した商品-売却済み
+        %i.fas.fa-angle-right
+    = link_to "", class:"l-side__list__link__area__name" do
+      %li.l-side__list__link
+        購入した商品-取引中
+        %i.fas.fa-angle-right
+    = link_to "", class:"l-side__list__link__area__name" do
+      %li.l-side__list__link
+        購入した商品-過去の取引
+        %i.fas.fa-angle-right
+    = link_to "", class:"l-side__list__link__area__name" do
+      %li.l-side__list__link
+        ニュース一覧
+        %i.fas.fa-angle-right
+    = link_to "", class:"l-side__list__link__area__name" do
+      %li.l-side__list__link
+        評価一覧
+        %i.fas.fa-angle-right
+    = link_to "", class:"l-side__list__link__area__name" do
+      %li.l-side__list__link
+        ガイド
+        %i.fas.fa-angle-right
+    = link_to "", class:"l-side__list__link__area__name" do
+      %li.l-side__list__link
+        お問い合わせ
+        %i.fas.fa-angle-right      
 
     %h3.mypage-nav-head
       メルペイ
       %ul.l-side__list
-        %li.l-side__list__link
-          = link_to "売上・振込申請", "", class:"l-side__list__link__area__name"
-          %i.fas.fa-angle-right
-        %li.l-side__list__link
-          = link_to "ポイント", "", class:"l-side__list__link__area__name"
-          %i.fas.fa-angle-right  
+        = link_to "", class:"l-side__list__link__area__name" do
+          %li.l-side__list__link
+            売上・振込申請
+            %i.fas.fa-angle-right
+        = link_to "", class:"l-side__list__link__area__name" do
+          %li.l-side__list__link
+            ポイント
+            %i.fas.fa-angle-right  
 
     %h3.mypage-nav-head
       設定
       %ul.l-side__list
-        %li.l-side__list__link
-          = link_to "プロフィール", edit_user_path(current_user), class:"l-side__list__link__area__name"
-          %i.fas.fa-angle-right
-        %li.l-side__list__link
-          = link_to "発送元・お届け先住所変更", "", class:"l-side__list__link__area__name"
-          %i.fas.fa-angle-right
-        %li.l-side__list__link
-          = link_to "支払い方法", "", class:"l-side__list__link__area__name"
-          %i.fas.fa-angle-right
-        %li.l-side__list__link
-          = link_to "メール/パスワード", "", class:"l-side__list__link__area__name"
-          %i.fas.fa-angle-right
-        %li.l-side__list__link
-          = link_to "本人情報", "", class:"l-side__list__link__area__name"
-          %i.fas.fa-angle-right
-        %li.l-side__list__link
-          = link_to "電話番号の確認", "", class:"l-side__list__link__area__name"
-          %i.fas.fa-angle-right
-        %li.l-side__list__link
-          = link_to "ログアウト", mypage_path(current_user), class:"l-side__list__link__area__name"
-          %i.fas.fa-angle-right
+        = link_to edit_user_path(current_user), class:"l-side__list__link__area__name" do
+          %li.l-side__list__link
+            プロフィール
+            %i.fas.fa-angle-right
+        = link_to "", class:"l-side__list__link__area__name" do
+          %li.l-side__list__link
+            発送元・お届け先住所変更
+            %i.fas.fa-angle-right
+        = link_to "", class:"l-side__list__link__area__name" do
+          %li.l-side__list__link
+            支払い方法
+            %i.fas.fa-angle-right
+        = link_to "", class:"l-side__list__link__area__name" do
+          %li.l-side__list__link
+            メール/パスワード
+            %i.fas.fa-angle-right
+        = link_to "", class:"l-side__list__link__area__name" do
+          %li.l-side__list__link
+            本人情報
+            %i.fas.fa-angle-right
+        = link_to "", class:"l-side__list__link__area__name" do
+          %li.l-side__list__link
+            電話番号の確認
+            %i.fas.fa-angle-right
+        = link_to mypage_path(current_user), class:"l-side__list__link__area__name" do
+          %li.l-side__list__link
+            ログアウト
+            %i.fas.fa-angle-right

--- a/app/views/mypage/_mypage-sidemenu.html.haml
+++ b/app/views/mypage/_mypage-sidemenu.html.haml
@@ -1,6 +1,6 @@
 .l-side
   %ul.l-side__list
-    = link_to "", class:"l-side__list__link__area__name" do
+    = link_to mypage_index_path, class:"l-side__list__link__area__name" do
       %li.l-side__list__link
         マイページ
         %i.fas.fa-angle-right


### PR DESCRIPTION
# WHAT
マイページのサイドバー
リンクの有効範囲をリスト項目全体に変更

# WHY
ユーザーがリンクを押しやすくするため